### PR TITLE
`#[sealed(airtight)]` and guarantees for `unsafe` code

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,10 @@ docs-rs = [
 [build]
 rustdocflags = [
     "--html-before-content", "fix-docsrs-li-details-summary.html",
+    "--cfg", "doc_examples",
+]
+rustflags=[
+    "--cfg", "doc_examples",
 ]
 
 [doc.extern-map.registries]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,14 +22,14 @@ dependencies = [
 
 [[package]]
 name = "seal-the-deal"
-version = "0.1.0"
+version = "0.1.1-rc1"
 dependencies = [
  "seal-the-deal-proc_macros",
 ]
 
 [[package]]
 name = "seal-the-deal-proc_macros"
-version = "0.1.0"
+version = "0.1.1-rc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,14 +22,14 @@ dependencies = [
 
 [[package]]
 name = "seal-the-deal"
-version = "0.1.1-rc2"
+version = "0.1.1"
 dependencies = [
  "seal-the-deal-proc_macros",
 ]
 
 [[package]]
 name = "seal-the-deal-proc_macros"
-version = "0.1.1-rc2"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,14 +22,14 @@ dependencies = [
 
 [[package]]
 name = "seal-the-deal"
-version = "0.1.1-rc1"
+version = "0.1.1-rc2"
 dependencies = [
  "seal-the-deal-proc_macros",
 ]
 
 [[package]]
 name = "seal-the-deal-proc_macros"
-version = "0.1.1-rc1"
+version = "0.1.1-rc2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ keywords = [
     "seal", "sealed", "final", "method", "override",
 ]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(doc_examples)',
+]
+
 [features]
 default = [
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "seal-the-deal"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.1.1-rc1"  # Keep in sync
+version = "0.1.1-rc2"  # Keep in sync
 edition = "2021"
 rust-version = "1.78.0"
 
@@ -49,7 +49,7 @@ docs-rs = [
 
 [dependencies.seal-the-deal-proc_macros]
 path = "src/proc_macros"
-version = "=0.1.1-rc1"  # Keep in sync
+version = "=0.1.1-rc2"  # Keep in sync
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ members = [
 features = [
     "docs-rs",
 ]
+rustc-args = [
+    "--cfg", "doc_examples",
+]
 rustdoc-args = [
     # Use (with or without `open`):
     # ```md
@@ -66,3 +69,5 @@ rustdoc-args = [
     # to get nice drop-down menus (and avoid the css bug with rustdoc).
     "--html-before-content", "fix-docsrs-li-details-summary.html",
 ]
+# We are not target-sensitive.
+targets = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ rustc-args = [
     "--cfg", "doc_examples",
 ]
 rustdoc-args = [
+    "--cfg", "doc_examples",
     # Use (with or without `open`):
     # ```md
     # <details open class="custom"><summary><span class="summary-box"><span>Click to hide</span></span></summary>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "seal-the-deal"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.1.0"  # Keep in sync
+version = "0.1.1-rc1"  # Keep in sync
 edition = "2021"
 rust-version = "1.78.0"
 
@@ -43,7 +43,7 @@ docs-rs = [
 
 [dependencies.seal-the-deal-proc_macros]
 path = "src/proc_macros"
-version = "=0.1.0"  # Keep in sync
+version = "=0.1.1-rc1"  # Keep in sync
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "seal-the-deal"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.1.1-rc2"  # Keep in sync
+version = "0.1.1"  # Keep in sync
 edition = "2021"
 rust-version = "1.78.0"
 
@@ -49,7 +49,7 @@ docs-rs = [
 
 [dependencies.seal-the-deal-proc_macros]
 path = "src/proc_macros"
-version = "=0.1.1-rc2"  # Keep in sync
+version = "=0.1.1"  # Keep in sync
 
 [dev-dependencies]
 

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -1,3 +1,5 @@
+//! [sealed]: `sealed`
+//! [with_seals]: `with_seals`
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![forbid(unsafe_code)]
@@ -90,35 +92,73 @@ pub use ::seal_the_deal_proc_macros::with_seals;
 /// `#[sealed]` are just syntactical annotations / markers for it. Which is why the `#[sealed]`
 /// attribute does not need to be imported in practice.
 ///
+/// # Attribute args
+///
+/// `#[sealed]` currently accepts _two_, optional, attribute args:
+///
+/// ## `#[sealed(airtight)]`
+///
+/// Switches the implementation used by `#[sealed]` from involving a generic lifetime parameter
+/// to involving more convoluted type-genericity tricks.
+///
+/// The author is positive this alternative method shall never allow users to override the method,
+/// no matter how smart the compiler might get, since doing so would require `fn` signatures to
+/// be capable of trait-resolution-fallback type inference.
+///
+/// The reason this alternative implementation is only opt-in, is because of a couple:
+///
+/// ### Caveats
+///
+///   - Since the method now uses a(n extra) generic type parameter, a previously `dyn`-compatible
+///     method would cease to be so.
+///
+///     Add `where Self : Sized` if you do not want the rest of the trait from becoming
+///     `dyn`-incompatible
+///
+///   - Uglier generated code.
+///
+///     Indeed, the return of the function [ends up wrapped in an ugly trait associated type][1].
+///
+///     While most code and users ought to remain blissfully oblivious to this fact, IDEs might
+///     reveal the ugly truth to users; moreover, the docs would be quite horrendous as well,
+///     which is why `#[sealed]` then defaults to hiding its shenanigans from the rendered docs, and
+///     [masquerading as non-`#[sealed] fn`][3] (but for the extra docstring appended to the method,
+///     of course!).
+///
+/// ## `#[sealed(doc(disguised = true/false))]`
+///
+/// Whether the attribute shall be using certain `cfg(doc)` shenanigans to disable itself when
+/// Rust documentation is being rendered, so as to hide the actual clutter/noise from said
+/// sheanigans.
+///
+///   - ### Default behavior
+///
+///       - For `#[sealed]`, it defaults to `false`: said sheanigans are deemed non-noisy enough
+///         not to warrant having to lie in docs;
+///
+///       - But for `#[sealed(airtight)]`, it defaults to `true`, since the return type of the
+///         method otherwise [ends up wrapped in an ugly trait associated type][1].
+///
+/// Note that no matter the choice of `doc(disguised)`, `#[sealed]` shall always unconditionally
+/// append a docstring to the method / associated function [telling users not to override it][2].
+///
+/// [1]: examples::AirtightDocDisguisedFalse::method()
+///
+/// [2]: examples::Basic::method()
+///
+/// [3]: examples::Airtight::method()
+///
+/// ---
+///
 /// See [the top-level docs][`crate`] for more info and examples.
 pub use ::seal_the_deal_proc_macros::sealed;
 
 #[doc = include_str!("compile_fail_tests.md")]
 mod _compile_fail_tests {}
 
-/// An example of the rendered docs of a <code>[#\[with_seals\]][`with_seals`]</code>-`trait`
-/// definition.
-///
-/// The source code for the trait was:
-///
-/// ```rust
-/// /// <these very docs>
-/// #[::seal_the_deal::with_seals]
-/// pub trait Example {
-///     #[sealed]
-///     /// This shall always return `42`.
-///     fn method(&self) -> i32 {
-///         42
-///     }
-/// }
-/// ```
-#[doc(cfg(docs))]
-#[cfg(feature = "docs-rs")]
-#[with_seals]
-pub trait Example {
-    #[sealed]
-    /// This shall always return `42`.
-    fn method(&self) -> i32 {
-        42
-    }
-}
+
+#[cfg_attr(feature = "docs-rs",
+    doc(cfg(doc_examples))
+)]
+#[cfg(doc_examples)]
+pub mod examples;

--- a/src/examples/airtight.rs
+++ b/src/examples/airtight.rs
@@ -1,0 +1,25 @@
+/// `#[sealed(airtight(doc(disguised = false)))]` case.
+///
+/// Example of the rendered docs of a
+/// <code>[#\[with_seals\]][`seal_the_deal::with_seals`]</code>-annotated `trait` definition.
+///
+/// The source code for the trait was:
+///
+/// ```rust
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", file!()))]
+/// ```
+#[seal_the_deal::with_seals]
+pub trait AirtightDocDisguisedFalse {
+    /// This shall always return `42`.
+    #[sealed(airtight, doc(disguised = false))]
+    fn method(&self) -> i32 {
+        42
+    }
+
+    /// This shall always call its arg and then return `42`.
+    #[sealed(airtight, doc(disguised = false))]
+    fn generic_method<F: FnOnce()>(&self, f: F) -> i32 {
+        f();
+        42
+    }
+}

--- a/src/examples/airtight_disguised.rs
+++ b/src/examples/airtight_disguised.rs
@@ -1,0 +1,26 @@
+/// `#[sealed(airtight)]` case.
+///
+/// Example of the rendered docs of a
+/// <code>[#\[with_seals\]][`seal_the_deal::with_seals`]</code>-annotated `trait` definition.
+///
+/// The source code for the trait was:
+///
+/// ```rust
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", file!()))]
+/// ```
+#[seal_the_deal::with_seals]
+pub trait Airtight {
+    /// This shall always return `42`.
+    #[sealed(airtight)]
+    // same as #[sealed(airtight, doc(disguised = true))]
+    fn method(&self) -> i32 {
+        42
+    }
+
+    /// This shall always call its arg and then return `42`.
+    #[sealed(airtight)]
+    fn generic_method<F: FnOnce()>(&self, f: F) -> i32 {
+        f();
+        42
+    }
+}

--- a/src/examples/basic.rs
+++ b/src/examples/basic.rs
@@ -1,0 +1,19 @@
+/// `#[sealed]` case.
+///
+/// Example of the rendered docs of a
+/// <code>[#\[with_seals\]][`seal_the_deal::with_seals`]</code>-annotated `trait` definition.
+///
+/// The source code for the trait was:
+///
+/// ```rust
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", file!()))]
+/// ```
+#[seal_the_deal::with_seals]
+pub trait Basic {
+    /// This shall always return `42`.
+    #[sealed]
+    // same as #[sealed(doc(disguised = false))]
+    fn method(&self) -> i32 {
+        42
+    }
+}

--- a/src/examples/basic_disguised.rs
+++ b/src/examples/basic_disguised.rs
@@ -1,0 +1,18 @@
+/// `#[sealed(doc(disguised = true))]` case.
+///
+/// Example of the rendered docs of a
+/// <code>[#\[with_seals\]][`seal_the_deal::with_seals`]</code>-annotated `trait` definition.
+///
+/// The source code for the trait was:
+///
+/// ```rust
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", file!()))]
+/// ```
+#[seal_the_deal::with_seals]
+pub trait BasicDocDisguised {
+    /// This shall always return `42`.
+    #[sealed(doc(disguised = true))]
+    fn method(&self) -> i32 {
+        42
+    }
+}

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,0 +1,220 @@
+extern crate self as seal_the_deal;
+
+include!("airtight.rs");
+include!("airtight_disguised.rs");
+include!("basic.rs");
+include!("basic_disguised.rs");
+
+/// Examples showcasing compiler diagnostics when attempting to override a
+/// [`#[sealed]`][crate::sealed] method.
+///
+/// # [`Basic`]
+///
+/// ```rust ,compile_fail
+/// struct Naive;
+///
+/// impl ::seal_the_deal::examples::Basic for Naive {
+///     fn method(&self) -> i32 { // naïve
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+/// error[E0195]: lifetime parameters or bounds on method `method` do not match the trait declaration
+///  --> src/examples/mod.rs:20:14
+///   |
+/// 8 |     fn method(&self) -> i32 { // naïve
+///   |              ^ lifetimes do not match method in trait
+/// # */
+/// ```
+///
+/// # [`Basic`], adversarial
+///
+/// ```rust ,compile_fail
+/// struct Evil;
+///
+/// impl ::seal_the_deal::examples::Basic for Evil {
+///     fn method<'huh>(&self) -> i32 { // evil
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+/// error[E0195]: lifetime parameters or bounds on method `method` do not match the trait declaration
+///  --> src/examples/mod.rs:42:14
+///   |
+/// 8 |     fn method<'huh>(&self) -> i32 { // evil
+///   |              ^^^^^^ lifetimes do not match method in trait
+/// # */
+/// ```
+///
+/// # [`Airtight`]
+///
+/// ```rust ,compile_fail
+/// struct Naive;
+///
+/// impl ::seal_the_deal::examples::Airtight for Naive {
+///     fn method(&self) -> i32 { // naïve
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+/// error[E0049]: method `method` has 0 type parameters but its trait declaration has 1 type parameter
+///   --> src/examples/mod.rs:39:14
+///    |
+/// 8  |       fn method(&self) -> i32 { // naïve
+///    |                ^ found 0 type parameters
+///    |
+///   ::: /Users/dhm/git/dhm/seal-the-deal.rs/src/examples/airtight_disguised.rs:13:7
+///    |
+/// 13 |       #[sealed(airtight)] // same as #[sealed(airtight, doc(disguised = true))]
+///    |  _______-
+/// 14 | |     /// This shall always return `42`.
+/// 15 | |     fn method(&self) -> i32 {
+///    | |______- expected 1 type parameter
+/// # */
+/// ```
+///
+/// # [`Airtight`] adversarial
+///
+/// ```rust ,compile_fail
+/// struct Evil;
+///
+/// impl ::seal_the_deal::examples::Airtight for Evil {
+///     fn method<T>(&self) -> i32 { // evil
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+/// error[E0053]: method `method` has an incompatible type for trait
+///  --> src/examples/mod.rs:58:28
+///   |
+/// 8 |     fn method<T>(&self) -> i32 { // evil
+///   |                            ^^^
+///   |                            |
+///   |                            expected associated type, found `i32`
+///   |                            help: change the output type to match the trait: `<() as examples::__Airtightඞseal_the_deal_airtight::Sealed<T>>::ඞRet<i32>`
+///   |
+///   = note: expected signature `fn(&Evil) -> <() as examples::__Airtightඞseal_the_deal_airtight::Sealed<T>>::ඞRet<i32>`
+///              found signature `fn(&Evil) -> i32`
+/// # */
+/// ```
+///
+/// # [`Airtight`]'s `.generic_method()`
+///
+/// ```rust ,compile_fail
+/// struct Naive;
+///
+/// impl ::seal_the_deal::examples::Airtight for Naive {
+///     fn generic_method<F: FnOnce()>(&self, f: F) -> i32 { // naïve
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+///  error[E0049]: method `generic_method` has 1 type parameter but its trait declaration has 2 type parameters
+///    --> src/examples/mod.rs:76:23
+///     |
+///  8  |       fn generic_method<F: FnOnce()>(&self, f: F) -> i32 { // naïve
+///     |                         ^ found 1 type parameter
+///     |
+///    ::: /Users/dhm/git/dhm/seal-the-deal.rs/src/examples/airtight_disguised.rs:19:7
+///     |
+///  19 |       #[sealed(airtight)]
+///     |  _______-
+///  20 | |     /// This shall always call its arg and then return `42`.
+///  21 | |     fn generic_method<F: FnOnce()>(&self, f: F) -> i32 {
+///     | |______- expected 2 type parameters
+/// # */
+/// ```
+///
+/// ## Stubborn
+///
+/// They might be tempted to keep trying:
+///
+/// ```rust ,compile_fail
+/// struct Stubborn;
+///
+/// impl ::seal_the_deal::examples::Airtight for Stubborn {
+///     fn generic_method<F: FnOnce(), Huh>(&self, f: F) -> i32 { // stubborn
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+/// error[E0643]: method `generic_method` has incompatible signature for trait
+///   --> src/examples/mod.rs:108:36
+///    |
+/// 8  |     fn generic_method<F: FnOnce(), Huh>(&self, f: F) -> i32 { // naïve
+///    |                                    ^^^ expected `impl Trait`, found generic parameter
+///    |
+///   ::: /Users/dhm/git/dhm/seal-the-deal.rs/src/examples/airtight_disguised.rs:19:7
+///    |
+/// 19 |     #[sealed(airtight)]
+///    |       ------ declaration in trait here
+/// # */
+/// ```
+///
+/// ## Cursed
+///
+/// They might be tempted to keep trying even further (not).
+///
+/// ```rust ,compile_fail
+/// struct Cursed;
+///
+/// trait Huh<U> {}
+/// impl<T, U> Huh<U> for T {}
+///
+/// impl ::seal_the_deal::examples::Airtight for Cursed {
+///     fn generic_method<F: FnOnce() + Huh<impl Sized>>(&self, f: F) -> i32 { // cursed
+///         0
+///     }
+/// }
+/// ```
+///
+/// They'd then get:
+///
+/// ```rust ,ignore
+/// # /*
+/// error[E0053]: method `generic_method` has an incompatible type for trait
+///   --> src/examples/mod.rs:140:70
+///    |
+/// 11 |     fn generic_method<F: FnOnce() + Huh<impl Sized>>(&self, f: F) -> i32 { // cursed
+///    |                                                                      ^^^
+///    |                                                                      |
+///    |                                                                      expected associated type, found `i32`
+///    |                                                                      help: change the output type to match the trait: `<F as examples::__Airtightඞseal_the_deal_airtight::Sealed<impl Sized>>::ඞRet<i32>`
+///    |
+///    = note: expected signature `fn(&Cursed, _) -> <F as examples::__Airtightඞseal_the_deal_airtight::Sealed<impl Sized>>::ඞRet<i32>`
+///               found signature `fn(&Cursed, _) -> i32`
+/// # */
+/// ```
+///
+pub
+mod ux_and_error_messages {}

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "seal-the-deal-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"
 ]
-version = "0.1.1-rc2"  # Keep in sync
+version = "0.1.1"  # Keep in sync
 edition = "2021"
 rust-version = "1.78.0"
 

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "seal-the-deal-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"
 ]
-version = "0.1.0"  # Keep in sync
+version = "0.1.1-rc1"  # Keep in sync
 edition = "2021"
 rust-version = "1.78.0"
 

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "seal-the-deal-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"
 ]
-version = "0.1.1-rc1"  # Keep in sync
+version = "0.1.1-rc2"  # Keep in sync
 edition = "2021"
 rust-version = "1.78.0"
 

--- a/src/proc_macros/_mod.rs
+++ b/src/proc_macros/_mod.rs
@@ -28,6 +28,8 @@ use ::syn::{*,
     spanned::Spanned,
 };
 
+mod args;
+
 ///
 #[proc_macro_attribute] pub
 fn with_seals(
@@ -51,6 +53,7 @@ fn with_seals(
         })
         .into()
 }
+
 #[derive(PartialEq)]
 enum Retain { Yes, Not }
 
@@ -61,12 +64,13 @@ fn with_seals_impl(
 {
     // By default deny any attribute present.
     let _: parse::Nothing = parse2(args)?;
-    let mut input: ItemTrait = parse2(input)?;
+    let mut trait_: ItemTrait = parse2(input)?;
+    let trait_name = &trait_.ident;
     let mut ret = quote!();
-    let storage = ::core::cell::OnceCell::new();
-    let mut helper_module_name = || -> &Ident {
-        storage.get_or_init(|| {
-            let trait_name = &input.ident;
+    let mut extra_methods = Vec::<TraitItem>::new();
+    let storage = (::core::cell::OnceCell::new(), ::core::cell::OnceCell::new());
+    let helper_module_name = |ret: &mut TokenStream2| -> &Ident {
+        storage.0.get_or_init(|| {
             let module_name = format_ident!("__{trait_name}ඞseal_the_deal");
             ret.extend(quote!(
                 #[allow(warnings, clippy::all)]
@@ -78,14 +82,37 @@ fn with_seals_impl(
             module_name
         })
     };
-    for assoc_item in &mut input.items {
+    let helper_module_name_airtight = |ret: &mut TokenStream2| -> &Ident {
+        storage.1.get_or_init(|| {
+            let module_name = format_ident!("__{trait_name}ඞseal_the_deal_airtight");
+            ret.extend(quote!(
+                #[allow(warnings, clippy::all)]
+                mod #module_name {
+                    pub trait Sealed<Seal> {
+                        type ඞRet<T>;
+                        fn ඞret<T>(_: T) -> Self::ඞRet<T>;
+                    }
+                    impl<X : ?Sized> Sealed<()> for X {
+                        type ඞRet<T> = T;
+                        #[inline]
+                        fn ඞret<T>(it: T) -> Self::ඞRet<T> {
+                            it
+                        }
+                    }
+                }
+            ));
+            module_name
+        })
+    };
+    for assoc_item in &mut trait_.items {
         // Only handle associated functions (_strictu sensu_, them being methods is not required.)
         let TraitItem::Fn(assoc_func) = assoc_item
         else {
             continue;
         };
-        let sealed_attr_span;
         // Only handle functions with a `#[sealed]` annotation on them:
+        let sealed_attr_span;
+        let sealed_attr_args: args::SealedArgs;
         {
             let sealed_attrs = &mut vec![];
             assoc_func.attrs.retain(|attr| Retain::Yes == if attr.path().is_ident("sealed") {
@@ -99,8 +126,11 @@ fn with_seals_impl(
                 | _no_sealed_attr_found @ [] => continue,
                 // Reject extraneous `…` in `#[sealed(…)]`
                 | [the_attr] => {
-                    the_attr.meta.require_path_only()?;
-                    sealed_attr_span = the_attr.path().span().resolved_at(Span::mixed_site());
+                    sealed_attr_args = match &the_attr.meta {
+                        | Meta::Path(_) => parse2(quote!())?,
+                        | _ => the_attr.parse_args()?,
+                    };
+                    sealed_attr_span = the_attr.path().span(); // .resolved_at(Span::mixed_site());
                 },
                 // Reject duplicate `#[sealed]`s.
                 | [_, redundant_attr, ..] => {
@@ -114,30 +144,196 @@ fn with_seals_impl(
                 ));
             }
         }
+        assoc_func.attrs.push(parse_quote!(
+            #[doc = "\
+                \n\
+                ---\n\
+                \n\
+                ## Sealed method\n\
+                \n\
+                This function is deliberately \"sealed\": it shall be impossible to override the \
+                default implementation in any kind of `impl` block whatsoever.\
+            "]
+        ));
+        let requested_airtight = sealed_attr_args.requested_airtight().unwrap_or(false);
+        if sealed_attr_args.requested_doc_disguised().unwrap_or(requested_airtight) {
+            let cfg_doc = quote!(
+                all(doc, not(doctest))
+            );
+            {
+                let mut assoc_func = assoc_func.clone();
+                assoc_func.attrs.push(parse_quote!(
+                    #[cfg(#cfg_doc)]
+                ));
+                extra_methods.push(TraitItem::Fn(assoc_func));
+            }
+            assoc_func.attrs.push(parse_quote!(
+                #[cfg(not(#cfg_doc))]
+            ));
+        }
         let generics = &mut assoc_func.sig.generics;
-        let extra_lifetime = {
-            let mut storage = None;
-            let lifetime_name: &str = {
-                let mut lifetime_name = "sealed";
-                for i in 0_u64.. {
-                    if generics.lifetimes().any(|lt| lt.lifetime.ident == lifetime_name) {
-                        lifetime_name = storage.insert(format!("ඞseal_the_deal__sealed{i}"));
-                    } else {
-                        break;
+        if requested_airtight.not() {
+            /* Strategy:
+            mod TraitName_seal_the_deal {
+                pub trait Seal<'__> {}
+                impl Seal<'_> for () {}
+            }
+            // and then use the following generics and clauses:
+            //           👇
+            fn method<'sealed>(…) -> …
+            where
+                …,
+                () : …::Seal<'sealed>, // 👈
+            */
+            let extra_lifetime = {
+                let mut storage = None;
+                let lifetime_name: &str = {
+                    let mut lifetime_name = "sealed";
+                    for i in 0_u64.. {
+                        if Iterator::chain(
+                                generics.lifetimes(),
+                                trait_.generics.lifetimes(),
+                            )
+                            .any(|lt| lt.lifetime.ident == lifetime_name)
+                        {
+                            lifetime_name = storage.insert(format!("ඞseal_the_deal__sealed{i}"));
+                        } else {
+                            break;
+                        }
+                    }
+                    lifetime_name
+                };
+                Lifetime::new(&format!("'{lifetime_name}"), sealed_attr_span)
+            };
+            let helper_module_name = helper_module_name(&mut ret);
+            generics.params.insert(
+                generics.lifetimes().count(),
+                parse_quote!( #extra_lifetime ),
+            );
+            generics.make_where_clause().predicates.push(parse_quote_spanned!(sealed_attr_span=>
+                () : #helper_module_name::Seal<#extra_lifetime>
+            ));
+        } else {
+            /* Strategy:
+            mod TraitName_seal_the_deal {
+                pub trait Seal<U> {
+                    type ඞRet<T>;
+                    fn ඞret<T>(_: T) -> Self::ඞRet<T>;
+                }
+                impl<X : ?Sized> Seal<()> for X {
+                    type ඞRet<T> = T;
+                    #[inline]
+                    fn ඞret<T>(it: T) -> Self::ඞRet<T> {
+                        it
                     }
                 }
-                lifetime_name
+            }
+            */
+            let helper_module_name = helper_module_name_airtight(&mut ret);
+            let SealTrait @ _ = quote_spanned!(sealed_attr_span=>
+                #helper_module_name::Sealed
+            );
+            let ret_ty = {
+                let ret_ty = &mut assoc_func.sig.output;
+                if matches!(ret_ty, ReturnType::Default) {
+                    *ret_ty = parse_quote_spanned!(sealed_attr_span=>
+                        -> ()
+                    );
+                }
+                if let ReturnType::Type(_, it) = ret_ty { it } else { unreachable!() }
             };
-            Lifetime::new(&format!("'{lifetime_name}"), sealed_attr_span)
-        };
-        let helper_module_name = helper_module_name();
-        generics.params.insert(
-            generics.lifetimes().count(),
-            parse_quote!( #extra_lifetime ),
-        );
-        generics.make_where_clause().predicates.push(parse_quote_spanned!(sealed_attr_span=>
-            () : #helper_module_name::Seal<#extra_lifetime>
-        ));
+            let fn_body = assoc_func.default.as_mut().unwrap();
+            let fn_body_catching_returns = if let Some(async_) = assoc_func.sig.asyncness {
+                quote_spanned!(async_.span()=>
+                    #async_ #fn_body .await
+                )
+            } else {
+                quote_spanned!(sealed_attr_span=>
+                    || -> _ #fn_body ()
+                )
+            };
+            // And then use the following generics and clauses:
+            if let Some(first_generic) = generics.type_params_mut().next() {
+                /* # If one generic type param already present:
+                //
+                //            vvvvvvvvvvvvvvvvvvv           vvvvvvvv   v
+                fn method<T : …::Seal<impl Sized>, …>(…) -> T::ඞRet< … >
+                …
+                {
+                    T::ඞret(|| -> _ { // 👈
+                        …
+                    }()) // 👈
+                }
+                */
+                first_generic.bounds.push(parse_quote_spanned!(sealed_attr_span=>
+                    #SealTrait<impl ::core::marker::Sized>
+                ));
+                let FirstT @ _ = &first_generic.ident;
+                **ret_ty = parse_quote_spanned!(sealed_attr_span=>
+                    #FirstT::ඞRet< #ret_ty >
+                );
+                let new_body = Stmt::Expr(
+                    parse_quote_spanned!(sealed_attr_span=>
+                        #FirstT::ඞret( #fn_body_catching_returns )
+                    ),
+                    None,
+                );
+                fn_body.stmts.splice(.., [
+                    new_body
+                ]);
+            } else {
+                /* # If no generic type params already present:
+                //
+                //          👇          vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv   v
+                fn method<Sealed>(…) -> <() as …::Seal<Sealed>>::ඞRet< … >
+                where
+                    …,
+                    () : …::Seal<Sealed>, // 👈
+                {
+                    <() as …::Seal<Sealed>>::ඞret(|| -> _ { // 👈
+                        …
+                    }()) // 👈
+                }
+                */
+                let SealArg @ _ = {
+                    let mut storage = None;
+                    let param_name: &str = {
+                        let mut param_name = "Seal";
+                        for i in 0_u64.. {
+                            if trait_.generics.type_params().any(|param| param.ident == param_name) {
+                                param_name = storage.insert(format!("ඞseal_the_deal__Seal{i}"));
+                            } else {
+                                break;
+                            }
+                        }
+                        param_name
+                    };
+                    Ident::new(param_name, sealed_attr_span)
+                };
+                generics.params.push(parse_quote_spanned!(sealed_attr_span=>
+                    #SealArg
+                ));
+                generics
+                    .make_where_clause()
+                    .predicates
+                    .push(parse_quote_spanned!(sealed_attr_span=>
+                        () : #SealTrait<#SealArg>
+                    ))
+                ;
+                **ret_ty = parse_quote_spanned!(sealed_attr_span=>
+                    <() as #SealTrait<#SealArg>>::ඞRet< #ret_ty >
+                );
+                let new_body = Stmt::Expr(
+                    parse_quote_spanned!(sealed_attr_span=>
+                        <() as #SealTrait<#SealArg>>::ඞret( #fn_body_catching_returns )
+                    ),
+                    None,
+                );
+                fn_body.stmts.splice(.., [
+                    new_body
+                ]);
+            }
+        }
         // span hacks to improve diagnostics:
         // When "lifetimes in impl do not match this method in trait", the diagnostic want to span
         // over the whole `< ... >` generics of the trait method.
@@ -152,22 +348,9 @@ fn with_seals_impl(
         // `Span::{call,mixed}_site()`, i.e., that of `#[with_seals]`).
         generics.lt_token = Some(Token![<](sealed_attr_span));
         generics.gt_token.get_or_insert_with(|| Token![>](sealed_attr_span));
-        assoc_func.attrs.push(parse_quote!(
-            #[doc = "\
-                \n\
-                ---\n\
-                \n\
-                ## Sealed method\n\
-                \n\
-                This function is deliberately \"sealed\": it shall be impossible to override the \
-                default implementation in any kind of `impl` block whatsoever.\n\
-                \n  \
-                  - (with the current implementation, an attempt to do so will fail with a \
-                    \"lifetimes do not match method in trait\" kind of error.)\
-            "]
-        ));
     }
-    input.to_tokens(&mut ret);
+    trait_.items.extend(extra_methods);
+    trait_.to_tokens(&mut ret);
     Ok(ret)
 }
 

--- a/src/proc_macros/args.rs
+++ b/src/proc_macros/args.rs
@@ -1,0 +1,96 @@
+use proc_macro2::extra::DelimSpan;
+
+use super::*;
+
+/// ```rust ,ignore
+/// #[sealed(
+///     // Optional
+///     airtight,
+///     // Optional
+///     doc(disguised = <true | false>),
+/// )]
+/// ```
+#[derive(Default)]
+pub(crate)
+struct SealedArgs {
+    pub(crate) airtight: Option<kw::airtight>,
+    pub(crate) doc_disguised: Option<(bool, kw::doc, token::Paren)>,
+    //                                      ^^^^^^^^^^^^^^^^^^^^^
+    //                                    used for spanning purposes
+}
+
+mod kw {
+    ::syn::custom_keyword!(airtight);
+    ::syn::custom_keyword!(doc);
+    ::syn::custom_keyword!(disguised);
+}
+
+impl Parse for SealedArgs {
+    fn parse(input: ParseStream<'_>) -> Result<SealedArgs> {
+        || -> Result<Self> {
+            let mut ret = Self::default();
+            while input.is_empty().not() {
+                let peeker = input.lookahead1();
+                match () {
+                    | _case if peeker.peek(kw::airtight) => {
+                        if ret.airtight.is_some() {
+                            return Err(input.error("duplicate arg"));
+                        }
+                        ret.airtight = Some(input.parse().unwrap());
+                    },
+                    | _case if peeker.peek(kw::doc) => {
+                        if ret.doc_disguised.is_some() {
+                            return Err(input.error("duplicate arg"));
+                        }
+                        let doc: kw::doc = input.parse().unwrap();
+                        {
+                            let contents;
+                            let parens = parenthesized!(contents in input);
+                            let input = contents;
+                            let _: kw::disguised = input.parse()?;
+                            let _: Token![=] = input.parse()?;
+                            let lit_bool: LitBool = input.parse()?;
+                            ret.doc_disguised = Some((
+                                lit_bool.value,
+                                doc,
+                                parens,
+                            ));
+                        }
+                    },
+                    | _default => return Err(peeker.error()),
+                }
+                let _: Option<Token![,]> = input.parse()?;
+            }
+            Ok(ret)
+        }().map_err(|mut err| {
+            err.combine(Error::new_spanned(
+                &err.to_compile_error(),
+                "\
+                    \n\
+                    usage:\n  \
+                    #[sealed]\n\
+                    or:\n  \
+                    #[sealed(\n    \
+                        // Optional\n    \
+                        airtight,\n    \
+                        // Optional\n    \
+                        doc(disguised = true/false),\n  \
+                    )]\
+                ",
+            ));
+            err
+        })
+    }
+}
+
+impl SealedArgs {
+    pub(crate)
+    fn requested_airtight(&self) -> Option<bool> {
+        self.airtight.as_ref().map(|_| true)
+    }
+
+    pub(crate)
+    fn requested_doc_disguised(&self) -> Option<bool> {
+        self.doc_disguised.as_ref().map(|&(b, ..)| b)
+    }
+}

--- a/tests/airtight.rs
+++ b/tests/airtight.rs
@@ -1,0 +1,65 @@
+#![allow(async_fn_in_trait)]
+
+use ::seal_the_deal::with_seals;
+
+#[with_seals]
+pub trait SomeTrait {
+    /// Shall always return `42`.
+    #[sealed(airtight)]
+    fn some_method(&self) -> i32 {
+        if false {
+            return 27;
+        }
+        42
+    }
+
+    #[sealed(airtight)]
+    fn generic_method<F: FnOnce()>(&self, f: F) -> i32 {
+        if false {
+            return 27;
+        }
+        f();
+        42
+    }
+
+    #[sealed(airtight)]
+    async fn async_method() -> u8 {
+        if false {
+            return 27;
+        }
+        async {}.await;
+        42
+    }
+
+    #[sealed(airtight)]
+    async fn async_generic_method<F: FnOnce()>(f: F) -> u8 {
+        if false {
+            return 27;
+        }
+        f();
+        async {}.await;
+        42
+    }
+
+    #[sealed]
+    fn basic(&self) -> i32 {
+        if false {
+            return 27;
+        }
+        42
+    }
+}
+
+async fn _call_sites<T: SomeTrait>(it: &T) {
+    let _: i32 = it.some_method();
+    it.some_method();
+
+    let _: i32 = it.basic();
+    it.basic();
+
+    let _: i32 = it.generic_method::<fn()>(|| ());
+    it.generic_method::<fn()>(|| ());
+
+    T::async_method().await;
+    let _: u8 = T::async_method().await;
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,54 @@
+#![allow(async_fn_in_trait)]
+
+use ::seal_the_deal::with_seals;
+
+#[with_seals]
+pub trait SomeTrait {
+    /// Shall always return `42`.
+    #[sealed]
+    fn some_method(&self) -> i32 {
+        if false {
+            return 27;
+        }
+        42
+    }
+
+    #[sealed]
+    fn generic_method<F: FnOnce()>(&self, f: F) -> i32 {
+        if false {
+            return 27;
+        }
+        f();
+        42
+    }
+
+    #[sealed]
+    async fn async_method() -> u8 {
+        if false {
+            return 27;
+        }
+        async {}.await;
+        42
+    }
+
+    #[sealed]
+    async fn async_generic_method<F: FnOnce()>(f: F) -> u8 {
+        if false {
+            return 27;
+        }
+        f();
+        async {}.await;
+        42
+    }
+}
+
+async fn _call_sites<T: SomeTrait>(it: &T) {
+    let _: i32 = it.some_method();
+    it.some_method();
+
+    let _: i32 = it.generic_method::<fn()>(|| ());
+    it.generic_method::<fn()>(|| ());
+
+    T::async_method().await;
+    let _: u8 = T::async_method().await;
+}


### PR DESCRIPTION
  - Fixes #1.

      - By better documenting the situation around `unsafe` code guarantees (_e.g._, advising against non-`airtight` usage with `unsafe` code);

      - and offering an opt-in `#[sealed(airtight)]` way to switch to an alternative implementation which is very much expected to be robust to any kind of compiler improvements;

cc @Jules-Bertholet